### PR TITLE
fix: files in folder errors

### DIFF
--- a/protos/file.proto
+++ b/protos/file.proto
@@ -135,7 +135,10 @@ message File {
     string description = 5;
     string ownerID = 6;
     int64 size = 7;
-    FileOrID parent = 10;
+    oneof fileOrId {
+        string parent = 8;
+        File parentObject = 9;
+    }
     string bucket = 11;
     string createdAt = 15;
     string updatedAt = 16;

--- a/src/file/file.rpc.ts
+++ b/src/file/file.rpc.ts
@@ -137,7 +137,10 @@ export class RPC {
     const folderID: string = call.request.folderID;
     const ownerID: string = call.request.ownerID;
     FileService.getFilesByFolder(folderID, ownerID)
-      .then(files => callback(null, files))
+      .then((files) => {
+        console.log(files);
+        callback(null, { files });
+      })
       .catch(err => callback(err));
   }
 


### PR DESCRIPTION
- The parent wasn't sent correctly in create file
- The files response wasn't sent correctly