### PR TITLE
Hotfix/logger

### DIFF
--- a/src/file/file.grpc.ts
+++ b/src/file/file.grpc.ts
@@ -44,7 +44,7 @@ export class FileMethods {
     const { updated, failed } = await FileService.updateMany(call.request.idList, call.request.partialFile);
     const traceID = getCurrTraceId();
     for (let i = 0; i < failed.length; i++) {
-      log(Severity.ERROR, 'update files error', failed[i].error.message, traceID, failed[i]);
+      log(Severity.ERROR, failed[i].error.message, 'update files error', traceID, failed[i]);
     }
     return { updated };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ export class FileServer {
     this.server = new grpc.Server();
     this.addServices();
     this.server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure());
-    log(Severity.INFO, 'server bind', `server listening on port: ${port}`);
+    log(Severity.INFO, `server listening on port: ${port}`, 'server bind');
   }
 
   private addServices() {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -63,7 +63,7 @@ export function wrapper(func: Function) :
       apm.startTransaction(`/file.FileService/${func.name}`, 'request', transOptions);
       const traceID: string = getCurrTraceId();
       const reqInfo: object = extractReqLog(call.request);
-      log(Severity.INFO, func.name, 'request', traceID, reqInfo);
+      log(Severity.INFO, 'request', func.name, traceID, reqInfo);
 
       const res = await func(call, callback);
       apm.endTransaction(statusToString(grpc.status.OK));

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,7 +11,7 @@ import { ApplicationError } from './errors/application.error';
 const indexTemplateMapping = require('winston-elasticsearch/index-template-mapping.json');
 indexTemplateMapping.index_patterns = `${confLogger.indexPrefix}-*`;
 
-export const logger = winston.createLogger({
+export const logger: winston.Logger = winston.createLogger({
   defaultMeta: { service: serviceName, hostname: os.hostname() },
 });
 
@@ -36,7 +36,7 @@ logger.add(elasticsearch);
  * @param meta - additional optional information.
  */
 export const log = (level: Severity, name: string, message: string, traceID?: string, meta?: object) => {
-  logger.log({ level, name, message, traceID, ...meta });
+  logger.log(level, name, { ...meta, traceID, mgs: message });
 };
 
 export enum Severity {


### PR DESCRIPTION
Fixed logger not working,
Now logger only saves the file ids of the files returned (if returned) - to save space.
Also, the request in the logger only contains the relevant fields.
Closes #127 