### PR TITLE
fixed environment variable #155

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ function getDB(confType: string) : DB {
   }
 }
 
-const esHost: string = process.env.LOGGER_ELASTICSEARCH || 'http://localhost:9200';
+const esHost: string = process.env.ELASTICSEARCH_URL || 'http://localhost:9200';
 const esUser: string = process.env.ELASTICSEARCH_USER || '';
 const esPass: string = process.env.ELASTICSEARCH_PASSWORD || '';
 export const confLogger = {


### PR DESCRIPTION
Small fix I forgotten to add. 
LOGGER_ELASTICSEARCH is deprecated now as an env. var
closes #155 
Signed-off-by: shahar-y <shya95@gmail.com>